### PR TITLE
Add "source" param to Transaction struct.

### DIFF
--- a/order.go
+++ b/order.go
@@ -253,6 +253,7 @@ type Transaction struct {
 	DeviceID       *int64           `json:"device_id,omitempty"`
 	ErrorCode      string           `json:"error_code,omitempty"`
 	SourceName     string           `json:"source_name,omitempty"`
+	Source         string           `json:"source,omitempty"`
 	PaymentDetails *PaymentDetails  `json:"payment_details,omitempty"`
 }
 


### PR DESCRIPTION
Param "source" value have to set "external" when create transaction using API.
see: https://community.shopify.com/c/Technical-Q-A/Can-not-to-create-transaction-for-order-using-API/m-p/509188/highlight/false#M6009